### PR TITLE
Add application confirmation page

### DIFF
--- a/app/routes/applied.tsx
+++ b/app/routes/applied.tsx
@@ -1,0 +1,39 @@
+export default function ApplicationConfirmation() {
+  return (
+    <main className="min-h screen relative m-auto">
+      <div className="flex h-screen w-full flex-col items-center justify-center">
+        <div className="flex w-1/2 flex-col items-center justify-center">
+          <div>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="#01A601"
+              className="size-24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+              />
+            </svg>
+          </div>
+          <div className="py-3 text-3xl font-bold">Thank you for applying!</div>
+          <div className="py-5 text-lg">
+            We will review your application and reach out if we need any more
+            information.
+          </div>
+          <div>
+            <button
+              type="submit"
+              className="rounded bg-repower-dark-blue px-10 py-3 font-semibold text-white hover:bg-blue-900"
+            >
+              <a href="/">Go Home</a>
+            </button>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/routes/apply.tsx
+++ b/app/routes/apply.tsx
@@ -25,7 +25,7 @@ export const meta: MetaFunction = () => [
 ];
 
 // TODO: Change this to different one
-const REDIRECT_URL = "/";
+const REDIRECT_URL = "/applied";
 
 interface ContractorBlockProps {
   errors?: Record<string, string>;


### PR DESCRIPTION
Add a confirmation page after user goes through the application and apply.

I added a page as `/applied` instead of confirmation, because if confirmation, it is hard to tell confirmation of what, but I am happy to change to the different URL.

![image](https://github.com/user-attachments/assets/27298e55-21d3-4e90-a682-2e8cfefe9106)
